### PR TITLE
Log control

### DIFF
--- a/src/wasm/include/web-ifc.h
+++ b/src/wasm/include/web-ifc.h
@@ -24,7 +24,18 @@ const uint32_t TAPE_SIZE = 1 << 24;
 
 namespace webifc
 {
-	struct LoaderSettings
+	enum class LogLevel
+	{
+		DEBUG = 0,
+		INFO = 1,
+		WARN = 2,
+		ERROR = 3,
+		OFF = 4
+	};
+
+        LogLevel LOG_LEVEL = LogLevel::INFO;
+
+        struct LoaderSettings
 	{
 		bool COORDINATE_TO_ORIGIN = false;
 		bool USE_FAST_BOOLS = false;
@@ -36,7 +47,44 @@ namespace webifc
 		int BOOL_ABORT_THRESHOLD = 10000; // 10k verts
 	};
 
-	enum class LoaderErrorType
+        void log(const std::string& msg, const LogLevel& level)
+	{
+          string sl;
+        	if (level >= LOG_LEVEL) {
+                	std::string fullMsg = msg;
+                        switch (level) {
+                                case LogLevel::DEBUG: fullMsg = "DEBUG: " + msg; sl = "debug"; break;
+                        	case LogLevel::INFO:  fullMsg = "INFO: "  + msg; sl = "info";  break;
+                        	case LogLevel::WARN:  fullMsg = "WARN: "  + msg; sl = "warn";  break;
+                        	case LogLevel::ERROR: fullMsg = "ERROR: " + msg; sl = "error";  break;
+                        	case LogLevel::OFF:   return;
+                                default:              fullMsg = msg; sl = "default";
+                        }
+                        std::cout << fullMsg << "AND LOG LEVEL IS: " << sl << std::endl;
+                }
+        }
+
+        void logDebug(const std::string& msg)
+        {
+          log(msg, LogLevel::DEBUG);
+        }
+
+        void logInfo(const std::string& msg)
+        {
+          log(msg, LogLevel::INFO);
+        }
+
+        void logWarn(const std::string& msg)
+        {
+          log(msg, LogLevel::WARN);
+        }
+
+        void logError(const std::string& msg)
+        {
+          log(msg, LogLevel::ERROR);
+        }
+
+        enum class LoaderErrorType
 	{
 		UNSPECIFIED,
 		PARSING,
@@ -52,13 +100,13 @@ namespace webifc
 		uint32_t ifcType;
 
 		LoaderError(LoaderErrorType t = LoaderErrorType::UNSPECIFIED,
-					std::string m = "",
-					uint32_t e = 0,
-					uint32_t type = 0) : type(t),
-										 message(m),
-										 expressID(e),
-										 ifcType(type)
-		{
+                            std::string m = "",
+                            uint32_t e = 0,
+                            uint32_t type = 0) : type(t),
+                                                 message(m),
+                                                 expressID(e),
+                                                 ifcType(type)
+                {
 		}
 	};
 
@@ -993,7 +1041,7 @@ namespace webifc
 			}
 
 			file << "ENDSEC;" << std::endl
-				 << "END-ISO-10303-21;";
+                             << "END-ISO-10303-21;";
 
 			return file.str();
 		}
@@ -1005,7 +1053,7 @@ namespace webifc
 
 		void ReportError(const LoaderError &&error)
 		{
-			std::cout << error.message << std::endl;
+                        logError(error.message);
 			_errors.push_back(std::move(error));
 		}
 

--- a/src/wasm/include/web-ifc.h
+++ b/src/wasm/include/web-ifc.h
@@ -24,13 +24,13 @@ const uint32_t TAPE_SIZE = 1 << 24;
 
 namespace webifc
 {
-	enum class LogLevel
+        enum class LogLevel : int
 	{
 		DEBUG = 0,
-		INFO = 1,
-		WARN = 2,
-		ERROR = 3,
-		OFF = 4
+		INFO,
+		WARN,
+		ERROR,
+		OFF
 	};
 
         LogLevel LOG_LEVEL = LogLevel::INFO;
@@ -49,18 +49,17 @@ namespace webifc
 
         void log(const std::string& msg, const LogLevel& level)
 	{
-          string sl;
         	if (level >= LOG_LEVEL) {
                 	std::string fullMsg = msg;
                         switch (level) {
-                                case LogLevel::DEBUG: fullMsg = "DEBUG: " + msg; sl = "debug"; break;
-                        	case LogLevel::INFO:  fullMsg = "INFO: "  + msg; sl = "info";  break;
-                        	case LogLevel::WARN:  fullMsg = "WARN: "  + msg; sl = "warn";  break;
-                        	case LogLevel::ERROR: fullMsg = "ERROR: " + msg; sl = "error";  break;
+                                case LogLevel::DEBUG: fullMsg = "DEBUG: " + msg; break;
+                        	case LogLevel::INFO:  fullMsg = "INFO: "  + msg; break;
+                        	case LogLevel::WARN:  fullMsg = "WARN: "  + msg; break;
+                        	case LogLevel::ERROR: fullMsg = "ERROR: " + msg; break;
                         	case LogLevel::OFF:   return;
-                                default:              fullMsg = msg; sl = "default";
+                                default:              fullMsg = msg;
                         }
-                        std::cout << fullMsg << "AND LOG LEVEL IS: " << sl << std::endl;
+                        std::cout << fullMsg << std::endl;
                 }
         }
 

--- a/src/wasm/include/web-ifc.h
+++ b/src/wasm/include/web-ifc.h
@@ -57,31 +57,15 @@ namespace webifc
                         	case LogLevel::WARN:  fullMsg = "WARN: "  + msg; break;
                         	case LogLevel::ERROR: fullMsg = "ERROR: " + msg; break;
                         	case LogLevel::OFF:   return;
-                                default:              fullMsg = msg;
                         }
                         std::cout << fullMsg << std::endl;
                 }
         }
 
-        void logDebug(const std::string& msg)
-        {
-          log(msg, LogLevel::DEBUG);
-        }
-
-        void logInfo(const std::string& msg)
-        {
-          log(msg, LogLevel::INFO);
-        }
-
-        void logWarn(const std::string& msg)
-        {
-          log(msg, LogLevel::WARN);
-        }
-
-        void logError(const std::string& msg)
-        {
-          log(msg, LogLevel::ERROR);
-        }
+        void logDebug(const std::string& msg) { log(msg, LogLevel::DEBUG); }
+        void logInfo(const std::string& msg)  { log(msg, LogLevel::INFO);  }
+        void logWarn(const std::string& msg)  { log(msg, LogLevel::WARN);  }
+        void logError(const std::string& msg) { log(msg, LogLevel::ERROR); }
 
         enum class LoaderErrorType
 	{

--- a/src/wasm/web-ifc-api.cpp
+++ b/src/wasm/web-ifc-api.cpp
@@ -695,21 +695,19 @@ extern "C" bool IsModelOpen(uint32_t modelID)
     return loader->IsOpen();
 }
 
-void SetLogLevel(const webifc::LogLevel& level)
+/**
+ * Sets the global log level.
+ * @param {number} levelArg Will be clamped between DEBUG and OFF.
+ */
+void SetLogLevel(int levelArg)
 {
-  webifc::LOG_LEVEL = level;
-  string sl;
-    switch (level) {
-      case webifc::LogLevel::DEBUG: sl = "d"; break;
-      case webifc::LogLevel::INFO: sl = "i"; break;
-      case webifc::LogLevel::WARN: sl = "w"; break;
-      case webifc::LogLevel::ERROR: sl = "e"; break;
-      case webifc::LogLevel::OFF:  sl = "o"; break; // intentional fallthrough
-      default:
-        std::cout << "HIT DEFAULT :( " << std::endl;
-        webifc::LOG_LEVEL = webifc::LogLevel::DEBUG; sl = "def";// be noisey if unknown level
+    if (levelArg < static_cast<int>(webifc::LogLevel::DEBUG)) {
+        webifc::LOG_LEVEL = webifc::LogLevel::DEBUG;
+    } else if (levelArg > static_cast<int>(webifc::LogLevel::OFF)) {
+        webifc::LOG_LEVEL = webifc::LogLevel::OFF;
+    } else {
+        webifc::LOG_LEVEL = static_cast<webifc::LogLevel>(levelArg);
     }
-        std::cout << "SETTING LOG LEVEL! " << sl << std::endl;
 }
 
 EMSCRIPTEN_BINDINGS(my_module) {

--- a/src/wasm/web-ifc-api.cpp
+++ b/src/wasm/web-ifc-api.cpp
@@ -698,7 +698,7 @@ extern "C" bool IsModelOpen(uint32_t modelID)
 // TODO(pablo): the level param ought to be LogLevel, but I couldn't
 // get the value passing from typescript correctly.  The levels are
 // kept in sync with src/web-ifc-api.ts
-)
+
 /**
  * Sets the global log level.
  * @data levelArg Will be clamped between DEBUG and OFF.

--- a/src/wasm/web-ifc-api.cpp
+++ b/src/wasm/web-ifc-api.cpp
@@ -64,8 +64,8 @@ int OpenModel(webifc::LoaderSettings settings, emscripten::val callback)
 {
     if (!shown_version_header)
     {
-      webifc::logInfo("web-ifc: " + WEB_IFC_VERSION_NUMBER +
-                      " threading: " + (MT_ENABLED ? "enabled" : "disabled"));
+        webifc::logInfo("web-ifc: " + WEB_IFC_VERSION_NUMBER +
+                        " threading: " + (MT_ENABLED ? "enabled" : "disabled"));
         shown_version_header = true;
     }
 
@@ -478,7 +478,7 @@ void WriteSet(webifc::DynamicTape<TAPE_SIZE>& _tape, emscripten::val& val)
         }
         else
         {
-          webifc::logError("Error in writeline: unknown object received");
+            webifc::logError("Error in writeline: unknown object received");
         }
 
         index++;

--- a/src/wasm/web-ifc-api.cpp
+++ b/src/wasm/web-ifc-api.cpp
@@ -695,9 +695,13 @@ extern "C" bool IsModelOpen(uint32_t modelID)
     return loader->IsOpen();
 }
 
+// TODO(pablo): the level param ought to be LogLevel, but I couldn't
+// get the value passing from typescript correctly.  The levels are
+// kept in sync with src/web-ifc-api.ts
+)
 /**
  * Sets the global log level.
- * @param {number} levelArg Will be clamped between DEBUG and OFF.
+ * @data levelArg Will be clamped between DEBUG and OFF.
  */
 void SetLogLevel(int levelArg)
 {

--- a/src/web-ifc-api.ts
+++ b/src/web-ifc-api.ts
@@ -119,9 +119,11 @@ export class IfcAPI
      */
     properties = new Properties(this);
 
+    logLevel = LogLevel.INFO
+
     /**
      * Initializes the WASM module (WebIFCWasm), required before using any other functionality.
-     * 
+     *
      * @param customLocateFileHandler An optional locateFile function that let's
      * you override the path from which the wasm module is loaded.
      */
@@ -133,7 +135,7 @@ export class IfcAPI
                 // when the wasm module requests the wasm file, we redirect to include the user specified path
                 if (path.endsWith(".wasm"))
                 {
-                    if (this.isWasmPathAbsolute) 
+                    if (this.isWasmPathAbsolute)
                     {
                         return this.wasmPath + path;
                     }
@@ -150,13 +152,8 @@ export class IfcAPI
         }
         else
         {
-            console.error(`Could not find wasm module at './web-ifc' from web-ifc-api.ts`);
+            this.LogError(`Could not find wasm module at './web-ifc' from web-ifc-api.ts`);
         }
-    }
-
-    SetLogLevel(level: LogLevel): void
-    {
-        this.wasmModule.SetLogLevel(level)
     }
 
     /**
@@ -220,7 +217,7 @@ export class IfcAPI
     }
 
 
-    /**  
+    /**
      * Opens a model and returns a modelID number
      * @modelID Model handle retrieved by OpenModel, model must not be closed
      * @data Buffer containing IFC data (bytes)
@@ -290,7 +287,7 @@ export class IfcAPI
         if (lineObject.expressID === undefined
             || lineObject.type === undefined
             || lineObject.ToTape === undefined) {
-            console.warn('Line object cannot be serialized; invalid format:', lineObject)
+            this.LogWarn('Line object cannot be serialized; invalid format:', lineObject)
             return
         }
 
@@ -345,7 +342,7 @@ export class IfcAPI
     {
         if (transformationMatrix.length != 16)
         {
-            console.log(`Bad transformation matrix size: ${transformationMatrix.length}`);
+            this.LogWarn(`Bad transformation matrix size: ${transformationMatrix.length}`);
             return;
         }
         this.wasmModule.SetGeometryTransformation(modelID, transformationMatrix);
@@ -370,7 +367,7 @@ export class IfcAPI
         return heap.subarray(startPtr / 4, startPtr / 4 + sizeBytes).slice(0);
     }
 
-    /**  
+    /**
      * Closes a model and frees all related memory
      * @modelID Model handle retrieved by OpenModel, model must not be closed
     */
@@ -390,7 +387,7 @@ export class IfcAPI
         this.wasmModule.StreamAllMeshesWithTypes(modelID, types, meshCallback);
     }
 
-    /**  
+    /**
      * Checks if a specific model ID is open or closed
      * @modelID Model handle retrieved by OpenModel
     */
@@ -399,7 +396,7 @@ export class IfcAPI
         return this.wasmModule.IsModelOpen(modelID);
     }
 
-    /**  
+    /**
      * Load all geometry in a model
      * @modelID Model handle retrieved by OpenModel
     */
@@ -408,7 +405,7 @@ export class IfcAPI
         return this.wasmModule.LoadAllGeometry(modelID);
     }
 
-    /**  
+    /**
      * Load geometry for a single element
      * @modelID Model handle retrieved by OpenModel
     */
@@ -450,5 +447,37 @@ export class IfcAPI
         this.isWasmPathAbsolute = absolute;
     }
 
+    SetLogLevel(level: LogLevel): void
+    {
+        this.logLevel = level;
+        this.wasmModule.SetLogLevel(level);
+    }
 
+    LogDebug(...msg: string[]): void
+    {
+        if (this.logLevel >= LogLevel.DEBUG) {
+            console.log('DEBUG:', ...msg);
+        }
+    }
+
+    LogInfo(...msg: string[]): void
+    {
+        if (this.logLevel >= LogLevel.INFO) {
+            console.log('INFO:', ...msg);
+        }
+    }
+
+    LogWarn(...msg: string[]): void
+    {
+        if (this.logLevel >= LogLevel.WARN) {
+            console.warn('WARN:', ...msg);
+        }
+    }
+
+    LogError(...msg: string[]): void
+    {
+        if (this.logLevel >= LogLevel.ERROR) {
+            console.error('ERROR:', ...msg);
+        }
+    }
 }

--- a/src/web-ifc-api.ts
+++ b/src/web-ifc-api.ts
@@ -42,6 +42,9 @@ export interface LoaderSettings
     PRINT_VERSION_STRING?: boolean;
 }
 
+
+// TODO(pablo): Don't know how to get static refs to the values, so
+// manually keeping in-sync with src/wasm/include/web-ifc.h.
 export enum LogLevel
 {
     DEBUG = 0,
@@ -153,7 +156,6 @@ export class IfcAPI
 
     SetLogLevel(level: LogLevel): void
     {
-        console.log('setting log level: ', level)
         this.wasmModule.SetLogLevel(level)
     }
 
@@ -288,7 +290,7 @@ export class IfcAPI
         if (lineObject.expressID === undefined
             || lineObject.type === undefined
             || lineObject.ToTape === undefined) {
-            console.warn('Line object cannot be serialized:', lineObject)
+            console.warn('Line object cannot be serialized; invalid format:', lineObject)
             return
         }
 

--- a/src/web-ifc-api.ts
+++ b/src/web-ifc-api.ts
@@ -39,7 +39,6 @@ export interface LoaderSettings
     CIRCLE_SEGMENTS_MEDIUM?: number;
     CIRCLE_SEGMENTS_HIGH?: number;
     BOOL_ABORT_THRESHOLD?: number;
-    PRINT_VERSION_STRING?: boolean;
 }
 
 

--- a/src/web-ifc-api.ts
+++ b/src/web-ifc-api.ts
@@ -33,12 +33,22 @@ export const LINE_END = 9;
 
 export interface LoaderSettings
 {
-    COORDINATE_TO_ORIGIN: boolean;
-    USE_FAST_BOOLS: boolean;
-    CIRCLE_SEGMENTS_LOW?: number
-    CIRCLE_SEGMENTS_MEDIUM?: number
-    CIRCLE_SEGMENTS_HIGH?: number
-    BOOL_ABORT_THRESHOLD?: number
+    COORDINATE_TO_ORIGIN?: boolean;
+    USE_FAST_BOOLS?: boolean;
+    CIRCLE_SEGMENTS_LOW?: number;
+    CIRCLE_SEGMENTS_MEDIUM?: number;
+    CIRCLE_SEGMENTS_HIGH?: number;
+    BOOL_ABORT_THRESHOLD?: number;
+    PRINT_VERSION_STRING?: boolean;
+}
+
+export enum LogLevel
+{
+    DEBUG = 0,
+    INFO = 1,
+    WARN = 2,
+    ERROR = 3,
+    OFF = 4,
 }
 
 export interface Vector<T> {
@@ -141,7 +151,13 @@ export class IfcAPI
         }
     }
 
-    /**  
+    SetLogLevel(level: LogLevel): void
+    {
+        console.log('setting log level: ', level)
+        this.wasmModule.SetLogLevel(level)
+    }
+
+    /**
      * Opens a model and returns a modelID number
      * @data Buffer containing IFC data (bytes)
      * @data Settings settings for loading the model
@@ -157,7 +173,6 @@ export class IfcAPI
             BOOL_ABORT_THRESHOLD: 10000,
             ...settings
         };
-
         let offsetInSrc = 0;
         let result = this.wasmModule.OpenModel(s, (destPtr: number, destSize: number) => {
             let srcSize = Math.min(data.byteLength - offsetInSrc, destSize);
@@ -174,7 +189,7 @@ export class IfcAPI
         return result;
     }
 
-    /**  
+    /**
      * Creates a new model and returns a modelID number
      * @data Settings settings for generating data the model
     */

--- a/tests/functional/Properties.spec.ts
+++ b/tests/functional/Properties.spec.ts
@@ -15,7 +15,7 @@ beforeAll(async () => {
 
     const exampleIFCPath = path.join(__dirname, '../artifacts/example.ifc.test');
     const exampleIFCData = fs.readFileSync(exampleIFCPath);
-    modelID = ifcApi.OpenModel(exampleIFCData);
+    modelID = ifcApi.OpenModel(exampleIFCData, {PRINT_VERSION_STRING: false});
     properties = ifcApi.properties
 })
 

--- a/tests/functional/Properties.spec.ts
+++ b/tests/functional/Properties.spec.ts
@@ -15,7 +15,7 @@ beforeAll(async () => {
     ifcApi.SetLogLevel(WebIFC.LogLevel.OFF);
     const exampleIFCPath = path.join(__dirname, '../artifacts/example.ifc.test');
     const exampleIFCData = fs.readFileSync(exampleIFCPath);
-    modelID = ifcApi.OpenModel(exampleIFCData, {PRINT_VERSION_STRING: false});
+    modelID = ifcApi.OpenModel(exampleIFCData);
     properties = ifcApi.properties
 })
 

--- a/tests/functional/Properties.spec.ts
+++ b/tests/functional/Properties.spec.ts
@@ -12,7 +12,7 @@ let properties : Properties
 beforeAll(async () => {
     ifcApi = new WebIFC.IfcAPI();
     await ifcApi.Init();
-
+    ifcApi.SetLogLevel(WebIFC.LogLevel.OFF);
     const exampleIFCPath = path.join(__dirname, '../artifacts/example.ifc.test');
     const exampleIFCData = fs.readFileSync(exampleIFCPath);
     modelID = ifcApi.OpenModel(exampleIFCData, {PRINT_VERSION_STRING: false});

--- a/tests/functional/WebIfcApi.spec.ts
+++ b/tests/functional/WebIfcApi.spec.ts
@@ -3,35 +3,61 @@ import * as path from 'path';
 import * as WebIFC from '../../dist/web-ifc-api-node.js';
 import type { Vector, FlatMesh, IfcAPI } from '../../dist/web-ifc-api-node.js';
 
-let modelID : number
+
+let modelId : number
 let ifcApi : IfcAPI
+
+
 beforeAll(async () => {
     ifcApi = new WebIFC.IfcAPI();
     await ifcApi.Init();
 
     const exampleIFCPath = path.join(__dirname, '../artifacts/example.ifc.test');
     const exampleIFCData = fs.readFileSync(exampleIFCPath);
-    modelID = ifcApi.OpenModel(exampleIFCData);
+    modelId = ifcApi.OpenModel(exampleIFCData);
 })
 
+
 describe('WebIfcApi', () => {
-    test('can retrieve a modelID', () => {
-        expect(modelID).toBe(0);
+    test('can retrieve a modelId', () => {
+        expect(modelId).toBe(0);
     })
 
     test('can ensure model is open', () => {
-        const isOpen : boolean = ifcApi.IsModelOpen(modelID);
+        const isOpen : boolean = ifcApi.IsModelOpen(modelId);
         expect(isOpen).toBeTruthy();
     })
 
     test('can return the correct number of elements', () => {
-        const geometry : Vector<FlatMesh> = ifcApi.LoadAllGeometry(modelID);
+        const geometry : Vector<FlatMesh> = ifcApi.LoadAllGeometry(modelId);
         expect(geometry.size()).toBe(119);
+    })
+
+    test('can write a new property value and read it back in', async () => {
+      async function getFirstStorey(api, mId) {
+        const storeyIds = await api.properties.getAllItemsOfType(mId, WebIFC.IFCBUILDINGSTOREY, false);
+        expect(storeyIds.length).toBe(2);
+        const storeyId = storeyIds[0];
+        const storey = await api.properties.getItemProperties(mId, storeyId);
+        return [storey, storeyId];
+      }
+      let [storey, storeyId] = await getFirstStorey(ifcApi, modelId);
+      const newStoreyName = 'Nivel 1 - Editado'
+      storey.LongName.value = newStoreyName;
+      ifcApi.WriteLine(modelId, storey);
+      storey = await ifcApi.properties.getItemProperties(modelId, storeyId);
+      expect(storey.LongName.value).toBe(newStoreyName);
+
+      const writtenData = await ifcApi.ExportFileAsIFC(modelId);
+      modelId = ifcApi.OpenModel(writtenData);
+      [storey, storeyId] = await getFirstStorey(ifcApi, modelId);
+      expect(storey.LongName.value).toBe(newStoreyName);
     })
 })
 
+
 afterAll(() => {
-    ifcApi.CloseModel(modelID);
-    const isOpen : boolean = ifcApi.IsModelOpen(modelID);
+    ifcApi.CloseModel(modelId);
+    const isOpen : boolean = ifcApi.IsModelOpen(modelId);
     expect(isOpen).toBeFalsy()
 })

--- a/tests/functional/WebIfcApi.spec.ts
+++ b/tests/functional/WebIfcApi.spec.ts
@@ -10,11 +10,12 @@ let ifcApi : IfcAPI
 
 beforeAll(async () => {
     ifcApi = new WebIFC.IfcAPI();
-    await ifcApi.Init();
-
+  await ifcApi.Init();
+  console.log('here is the value for OFF: ', WebIFC.LogLevel.OFF)
+    ifcApi.SetLogLevel(WebIFC.LogLevel.OFF);
     const exampleIFCPath = path.join(__dirname, '../artifacts/example.ifc.test');
     const exampleIFCData = fs.readFileSync(exampleIFCPath);
-    modelId = ifcApi.OpenModel(exampleIFCData);
+      modelId = ifcApi.OpenModel(exampleIFCData);
 })
 
 

--- a/tests/functional/WebIfcApi.spec.ts
+++ b/tests/functional/WebIfcApi.spec.ts
@@ -3,11 +3,8 @@ import * as path from 'path';
 import * as WebIFC from '../../dist/web-ifc-api-node.js';
 import type { Vector, FlatMesh, IfcAPI } from '../../dist/web-ifc-api-node.js';
 
-
 let modelID : number
 let ifcApi : IfcAPI
-
-
 beforeAll(async () => {
     ifcApi = new WebIFC.IfcAPI();
     await ifcApi.Init();
@@ -16,7 +13,6 @@ beforeAll(async () => {
     const exampleIFCData = fs.readFileSync(exampleIFCPath);
     modelID = ifcApi.OpenModel(exampleIFCData);
 })
-
 
 describe('WebIfcApi', () => {
     test('can retrieve a modelID', () => {
@@ -33,7 +29,6 @@ describe('WebIfcApi', () => {
         expect(geometry.size()).toBe(119);
     })
 })
-
 
 afterAll(() => {
     ifcApi.CloseModel(modelID);

--- a/tests/functional/WebIfcApi.spec.ts
+++ b/tests/functional/WebIfcApi.spec.ts
@@ -10,12 +10,11 @@ let ifcApi : IfcAPI
 
 beforeAll(async () => {
     ifcApi = new WebIFC.IfcAPI();
-  await ifcApi.Init();
-  console.log('here is the value for OFF: ', WebIFC.LogLevel.OFF)
+    await ifcApi.Init();
     ifcApi.SetLogLevel(WebIFC.LogLevel.OFF);
     const exampleIFCPath = path.join(__dirname, '../artifacts/example.ifc.test');
     const exampleIFCData = fs.readFileSync(exampleIFCPath);
-      modelId = ifcApi.OpenModel(exampleIFCData);
+    modelId = ifcApi.OpenModel(exampleIFCData);
 })
 
 

--- a/tests/functional/WebIfcApi.spec.ts
+++ b/tests/functional/WebIfcApi.spec.ts
@@ -4,7 +4,7 @@ import * as WebIFC from '../../dist/web-ifc-api-node.js';
 import type { Vector, FlatMesh, IfcAPI } from '../../dist/web-ifc-api-node.js';
 
 
-let modelId : number
+let modelID : number
 let ifcApi : IfcAPI
 
 
@@ -14,50 +14,29 @@ beforeAll(async () => {
     ifcApi.SetLogLevel(WebIFC.LogLevel.OFF);
     const exampleIFCPath = path.join(__dirname, '../artifacts/example.ifc.test');
     const exampleIFCData = fs.readFileSync(exampleIFCPath);
-    modelId = ifcApi.OpenModel(exampleIFCData);
+    modelID = ifcApi.OpenModel(exampleIFCData);
 })
 
 
 describe('WebIfcApi', () => {
-    test('can retrieve a modelId', () => {
-        expect(modelId).toBe(0);
+    test('can retrieve a modelID', () => {
+        expect(modelID).toBe(0);
     })
 
     test('can ensure model is open', () => {
-        const isOpen : boolean = ifcApi.IsModelOpen(modelId);
+        const isOpen : boolean = ifcApi.IsModelOpen(modelID);
         expect(isOpen).toBeTruthy();
     })
 
     test('can return the correct number of elements', () => {
-        const geometry : Vector<FlatMesh> = ifcApi.LoadAllGeometry(modelId);
+        const geometry : Vector<FlatMesh> = ifcApi.LoadAllGeometry(modelID);
         expect(geometry.size()).toBe(119);
-    })
-
-    test('can write a new property value and read it back in', async () => {
-      async function getFirstStorey(api, mId) {
-        const storeyIds = await api.properties.getAllItemsOfType(mId, WebIFC.IFCBUILDINGSTOREY, false);
-        expect(storeyIds.length).toBe(2);
-        const storeyId = storeyIds[0];
-        const storey = await api.properties.getItemProperties(mId, storeyId);
-        return [storey, storeyId];
-      }
-      let [storey, storeyId] = await getFirstStorey(ifcApi, modelId);
-      const newStoreyName = 'Nivel 1 - Editado'
-      storey.LongName.value = newStoreyName;
-      ifcApi.WriteLine(modelId, storey);
-      storey = await ifcApi.properties.getItemProperties(modelId, storeyId);
-      expect(storey.LongName.value).toBe(newStoreyName);
-
-      const writtenData = await ifcApi.ExportFileAsIFC(modelId);
-      modelId = ifcApi.OpenModel(writtenData);
-      [storey, storeyId] = await getFirstStorey(ifcApi, modelId);
-      expect(storey.LongName.value).toBe(newStoreyName);
     })
 })
 
 
 afterAll(() => {
-    ifcApi.CloseModel(modelId);
-    const isOpen : boolean = ifcApi.IsModelOpen(modelId);
+    ifcApi.CloseModel(modelID);
+    const isOpen : boolean = ifcApi.IsModelOpen(modelID);
     expect(isOpen).toBeFalsy()
 })


### PR DESCRIPTION
This PR introduces configurable control of logging levels: DEBUG, INFO, WARN, ERROR, OFF.  This is used to optionalize the version logging, i.e. to disable for jsconsole and unit tests.

NOTE: I'm debugging an issue where setting the log level from the TS wrapper doesn't take effect.