### PR TITLE
#183 Linked models does not align correctly in term of position and scale in some cases

### DIFF
--- a/examples/viewer/web-ifc-viewer.ts
+++ b/examples/viewer/web-ifc-viewer.ts
@@ -138,7 +138,7 @@ function getData(reader : FileReader){
 
 function LoadModel(data: Uint8Array) {
     const start = ms();
-    const modelID = ifcAPI.OpenModel(data, { COORDINATE_TO_ORIGIN: true, USE_FAST_BOOLS: false });
+    const modelID = ifcAPI.OpenModel(data, { COORDINATE_TO_ORIGIN: false, USE_FAST_BOOLS: false });
     const time = ms() - start;
     console.log(`Opening model took ${time} ms`);
     ifcThree.LoadAllGeometry(scene, modelID);

--- a/src/wasm/include/ifc-meta-data.h
+++ b/src/wasm/include/ifc-meta-data.h
@@ -20,6 +20,9 @@ namespace webifc
     struct IfcMetaData
     {
 		double linearScalingFactor = 1;
+		double squaredScalingFactor = 1;
+		double cubicScalingFactor = 1;
+		double angularScalingFactor = 1;
 
 		std::vector<IfcLine> lines;
 		std::vector<uint32_t> expressIDToLine;

--- a/src/wasm/include/web-ifc.h
+++ b/src/wasm/include/web-ifc.h
@@ -269,9 +269,38 @@ namespace webifc
 					if (unitType == "LENGTHUNIT" && unitName == "METRE")
 					{
 						double prefix = ConvertPrefix(unitPrefix);
-						_metaData.linearScalingFactor = prefix;
+						_metaData.linearScalingFactor *= prefix;
 					}
 				}
+				if(line.ifcType == ifc2x4::IFCCONVERSIONBASEDUNIT)
+				{
+					MoveToArgumentOffset(line, 1);
+					std::string unitType = GetStringArgument();
+					MoveToArgumentOffset(line, 3);
+					auto unitRefLine = GetRefArgument();
+					auto &unitLine = GetLine(ExpressIDToLineID(unitRefLine));
+					
+					MoveToArgumentOffset(unitLine, 1);
+					auto ratios = GetSetArgument();
+
+					double ratio = GetDoubleArgument(ratios[0]);
+					if(unitType == "LENGTHUNIT")
+					{
+						_metaData.linearScalingFactor *= ratio;
+					}
+					else if (unitType == "AREAUNIT")
+					{
+						_metaData.squaredScalingFactor *= ratio;
+					}
+					else if (unitType == "VOLUMEUNIT")
+					{
+						_metaData.cubicScalingFactor *= ratio;
+					}
+					else if (unitType == "PLANEANGLEUNIT")
+					{
+						_metaData.angularScalingFactor *= ratio;
+					}
+				}		
 			}
 		}
 


### PR DESCRIPTION
Added the logic to account for the IFCCONVERSIONBASEDUNIT values provided by the IFC files when the units of the model are different than the default metric units. This results in properly scaled models. Changed the "Coordinate_to_origin" option in the OpenModel function to "false" to allow the models to align using the two sample files provided in issue #183 

![image](https://user-images.githubusercontent.com/20270430/197681296-d90ef515-24a3-4643-a107-e956d48f9320.png)
