### PR TITLE
#224 GetLine always returns the first LineID if its expressId not exist

### DIFF
--- a/src/wasm/include/web-ifc.h
+++ b/src/wasm/include/web-ifc.h
@@ -455,6 +455,15 @@ namespace webifc
 			return _metaData.expressIDToLine.capacity() > expressID;
 		}
 
+		bool ValidateExpressID(uint32_t expressID)
+		{
+			std::vector<IfcLine>& lines = _metaData.lines;
+
+			auto check = find_if(lines.begin(), lines.end(), [&expressID](const IfcLine& obj){return obj.expressID == expressID;});
+
+			return (check != lines.end());
+		}
+
 		uint32_t ExpressIDToLineID(uint32_t expressID)
 		{
 			return _metaData.expressIDToLine[expressID];

--- a/src/wasm/web-ifc-api.cpp
+++ b/src/wasm/web-ifc-api.cpp
@@ -380,6 +380,17 @@ std::vector<uint32_t> GetLineIDsWithType(uint32_t modelID, uint32_t type)
     return expressIDs;
 }
 
+bool ValidateExpressID(uint32_t modelID, uint32_t expressId)
+{
+    auto& loader = loaders[modelID];
+    if (!loader)
+    {
+        return {};
+    }
+
+    return loader->ValidateExpressID(expressId);
+}
+
 std::vector<uint32_t> GetAllLines(uint32_t modelID)
 {
     auto& loader = loaders[modelID];
@@ -841,6 +852,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     emscripten::function("GetLine", &GetLine);
     emscripten::function("WriteLine", &WriteLine);
     emscripten::function("ExportFileAsIFC", &ExportFileAsIFC);
+    emscripten::function("ValidateExpressID", &ValidateExpressID);
     emscripten::function("GetLineIDsWithType", &GetLineIDsWithType);
     emscripten::function("GetInversePropertyForItem", &GetInversePropertyForItem);
     emscripten::function("GetAllLines", &GetAllLines);

--- a/src/web-ifc-api.ts
+++ b/src/web-ifc-api.ts
@@ -215,6 +215,11 @@ export class IfcAPI
 
     GetLine(modelID: number, expressID: number, flatten: boolean = false, inverse: boolean = false)
     {
+        let expressCheck = this.wasmModule.ValidateExpressID(modelID, expressID);  
+        if(!expressCheck){
+           return; 
+        }
+
         let rawLineData = this.GetRawLineData(modelID, expressID);
         let lineData = ifc2x4helper.FromRawLineData[rawLineData.type](rawLineData);
         


### PR DESCRIPTION
Added a validation check of the ExpressID to ensure it is in the IFC file checking for omitted intermediate ExpressIDs and returns an undefined value if the ExpressID doesn't exist to address #224