### PR TITLE
#213 Added GetAllTypesOfModel function to WebAPI

### DIFF
--- a/examples/viewer/web-ifc-viewer.ts
+++ b/examples/viewer/web-ifc-viewer.ts
@@ -136,7 +136,7 @@ function getData(reader : FileReader){
   return data;
 }
 
-function LoadModel(data: Uint8Array) {
+async function LoadModel(data: Uint8Array) {
     const start = ms();
     //TODO: This needs to be fixed in the future to rely on elalish/manifold
     const modelID = ifcAPI.OpenModel(data, { COORDINATE_TO_ORIGIN: false, USE_FAST_BOOLS: true }); 
@@ -149,6 +149,15 @@ function LoadModel(data: Uint8Array) {
     for (let i = 0; i < errors.size(); i++)
     {
         console.log(errors.get(i));
+    }
+
+    //Example to get all types used in the model
+    let types = await ifcAPI.GetAllTypesOfModel(modelID);
+    for (let i = 0; i < types.length; i++) {
+        let type = types[i];
+        console.log(type);
+        console.log(type.typeID);
+        console.log(type.typeName);
     }
 
     ifcAPI.CloseModel(modelID);

--- a/src/helpers/properties.ts
+++ b/src/helpers/properties.ts
@@ -92,6 +92,11 @@ export class Properties {
         return project;
     }
 
+    async getAllTypesFromModel(modelID: number){
+        await this.getAllTypesOfModel(modelID);
+        return this.types;
+    }
+
     async getAllItemsOfType(modelID: number, type: number, verbose: boolean) {
         let items: number[] = [];
         const lines = await this.api.GetLineIDsWithType(modelID, type);

--- a/src/web-ifc-api.ts
+++ b/src/web-ifc-api.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import {IfcElements} from "./ifc2x4";
+import {IfcTypesMap} from "./helpers/types-map";
 
 let WebIFCWasm;
 
@@ -84,6 +85,12 @@ export interface IfcGeometry
     GetVertexDataSize(): number;
     GetIndexData(): number;
     GetIndexDataSize(): number;
+}
+
+export interface ifcType
+{
+    typeID: number;
+    typeName: string;
 }
 
 export function ms() {
@@ -232,6 +239,24 @@ export class IfcAPI
     GetHeaderLine(modelID: number, headerType: number)
     {
         return this.wasmModule.GetHeaderLine(modelID, headerType);
+    }
+
+    async GetAllTypesOfModel(modelID: number): Promise<ifcType[]>
+    {
+        let intType: Vector<number> = await this.properties.getAllTypesFromModel(modelID);
+        let res: number[] = [];
+        for(let key in intType) {
+            let value = intType[key];
+            res.push(value);
+        }
+        let types = [... new Set(res)];
+        
+        let typesNames: ifcType[] = [];
+        for (let i = 0; i < types.length; i++) {
+            const type = types[i];
+            typesNames.push({typeID: type, typeName: IfcTypesMap[type]});
+        }
+        return typesNames;
     }
     
     GetLine(modelID: number, expressID: number, flatten: boolean = false, inverse: boolean = false)


### PR DESCRIPTION
Implemented a function to get a unique list of all IFC types within a given model returning an array of objects with typeID and typeName properties to address issue #213 

The function is asynchronous and returns a Promise so it needs to be awaited in an async function as demonstrated in the updated web-ifc-viewer.ts file.

 The array can be iterated through to find the typeID and typeName as required by the developer
 
 
![image](https://user-images.githubusercontent.com/20270430/199574995-3e4e5842-444e-4f03-b02e-0b65deb96439.png)
