### PR TITLE
#230 Get the next highest expressID: Added GetNextExpressID

### DIFF
--- a/src/wasm/web-ifc-api.cpp
+++ b/src/wasm/web-ifc-api.cpp
@@ -563,6 +563,33 @@ bool ValidateExpressID(uint32_t modelID, uint32_t expressId)
     return loader->ValidateExpressID(expressId);
 }
 
+uint32_t GetNextExpressID(uint32_t modelID, uint32_t expressId)
+{
+    auto& loader = loaders[modelID];
+    if(!loader)
+    {
+        return {};
+    }
+
+    uint32_t currentId = expressId;
+
+    bool cont = true;
+    uint32_t maxId = loader->GetMaxExpressId();
+
+    while(cont)
+    {
+        if(currentId >= maxId)
+        {
+            cont = false;
+            continue;
+        }
+        currentId++;
+        cont = !(loader->ValidateExpressID(currentId));
+    }
+
+    return currentId;
+}
+
 std::vector<uint32_t> GetAllLines(uint32_t modelID)
 {
     auto& loader = loaders[modelID];
@@ -1108,6 +1135,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     emscripten::function("WriteLine", &WriteLine);
     emscripten::function("ExportFileAsIFC", &ExportFileAsIFC);
     emscripten::function("ValidateExpressID", &ValidateExpressID);
+    emscripten::function("GetNextExpressID", &GetNextExpressID);
     emscripten::function("GetLineIDsWithType", &GetLineIDsWithType);
     emscripten::function("GetInversePropertyForItem", &GetInversePropertyForItem);
     emscripten::function("GetAllLines", &GetAllLines);

--- a/src/web-ifc-api.ts
+++ b/src/web-ifc-api.ts
@@ -321,6 +321,11 @@ export class IfcAPI
         return lineData;
     }
 
+    GetNextExpressID(modelID: number, expressID: number): number
+    {
+        return this.wasmModule.GetNextExpressID(modelID, expressID);
+    }
+
     GetAndClearErrors(modelID: number): Vector<LoaderError>
     {
         return this.wasmModule.GetAndClearErrors(modelID);

--- a/tests/functional/WebIfcApi.spec.ts
+++ b/tests/functional/WebIfcApi.spec.ts
@@ -143,7 +143,15 @@ describe('WebIfcApi reading methods', () => {
         ifcApi.CreateIfcGuidToExpressIdMapping(modelID);
         expect(ifcApi.ifcGuidMap.get(0)?.get(expressIDMatchingGuid.expressID)).toEqual(expressIDMatchingGuid.guid);
     })
-
+    test('can return the next highest expressID if the ID is sequential', () => {
+        expect(ifcApi.GetNextExpressID(modelID, 5)).toBe(6);
+    })
+    test('can return the next highest expressID if the ID is not sequential', () => {
+        expect(ifcApi.GetNextExpressID(modelID, 9)).toBe(11);
+    })
+    test('returns same expressID if it is the max ID', () => {
+        expect(ifcApi.GetNextExpressID(modelID, 14312)).toBe(14312);
+    })
 
 
 })


### PR DESCRIPTION
Added the function GetNextExpressID to the API to retrieve the next highest express ID from the IFC model. This resolves the issue #230 . The function takes in 2 parameters: model ID and express ID for the model and expressID of interest