### PR TITLE
Add support for writing new lines

### DIFF
--- a/src/web-ifc-api.ts
+++ b/src/web-ifc-api.ts
@@ -343,6 +343,10 @@ export class IfcAPI {
                 }
             }
         });
+        
+        if(lineObject.expressID === undefined || lineObject.expressID < 0) {
+            lineObject.expressID = this.IncrementMaxExpressID(modelID, 1);
+        }
 
         // See https://github.com/IFCjs/web-ifc/issues/178 for some pitfalls here.
         if (lineObject.expressID === undefined


### PR DESCRIPTION
Add support for writing new lines  in `WriteLine()`

If lineObject has expressID === undefined || < 0 , `IncrementMaxExpressID()` is called and assigned to expressID.   Checks for < 0, to be compliant with helper-classes, because instantiating those requires an `expressID: number`.    As `WriteLine()` is recursive, nested objects will have smaller expressIDs than the parent's.