### PR TITLE
Ensure a static version of EMSCRIPTEN 

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -13,6 +13,8 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: mymindstorm/setup-emsdk@v11
+        with:
+          version: 3.1.31
       - name: Checkout 🛎️
         uses: actions/checkout@v3
       - uses: actions/setup-node@v2

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -105,7 +105,7 @@ if (EMSCRIPTEN)
 	target_link_libraries(web-ifc-mt manifold)
 	target_compile_options(web-ifc-mt PUBLIC "-pthread")
 	target_compile_options(web-ifc-mt PUBLIC "-Wall")
-	set_target_properties(web-ifc-mt PROPERTIES LINK_FLAGS "${DEBUG_FLAG} -pthread -s PTHREAD_POOL_SIZE=navigator.hardwareConcurrency --bind -03 -flto --define-macro=REAL_T_IS_DOUBLE -s ALLOW_MEMORY_GROWTH=1 -s MAXIMUM_MEMORY=4GB -s DEFAULT_PTHREAD_STACK_SIZE=2MB -s FORCE_FILESYSTEM=1 -sSTACK_SIZE=5MB -s EXPORT_NAME=WebIFCWasm -s MODULARIZE=1 -s EXPORTED_RUNTIME_METHODS=[\"FS, WORKERFS\"] -lworkerfs.js")
+	set_target_properties(web-ifc-mt PROPERTIES LINK_FLAGS "${DEBUG_FLAG} -pthread -s PTHREAD_POOL_SIZE=navigator.hardwareConcurrency --bind -03 -flto --define-macro=REAL_T_IS_DOUBLE -s ALLOW_MEMORY_GROWTH=1 -s MAXIMUM_MEMORY=4GB -s FORCE_FILESYSTEM=1 -sSTACK_SIZE=5MB -s EXPORT_NAME=WebIFCWasm -s MODULARIZE=1 -s EXPORTED_RUNTIME_METHODS=[\"FS, WORKERFS\"] -lworkerfs.js")
 endif()
 
 


### PR DESCRIPTION
Sometimes EMSCRIPTEN make silent changes. We should ensure our automated builds do not change version unless we want it