### PR TITLE
=Fix registering StreamMeshes

### DIFF
--- a/src/wasm/web-ifc-api.cpp
+++ b/src/wasm/web-ifc-api.cpp
@@ -144,7 +144,7 @@ webifc::geometry::IfcFlatMesh GetFlatMesh(uint32_t modelID, uint32_t expressID)
     return mesh;
 }
 
-void StreamMeshes(uint32_t modelID, std::vector<uint32_t> expressIds, emscripten::val callback) {
+void StreamMeshes(uint32_t modelID, const std::vector<uint32_t> & expressIds, emscripten::val callback) {
     auto loader = models[modelID].GetLoader();
     auto geomLoader = models[modelID].GetGeometryLoader();
 
@@ -179,6 +179,24 @@ void StreamMeshes(uint32_t modelID, std::vector<uint32_t> expressIds, emscripten
 
         index++;
     }
+}
+
+void StreamMeshesVal(uint32_t modelID, emscripten::val expressIdsVal, emscripten::val callback)
+{
+    std::vector<uint32_t> expressIds;
+
+    uint32_t size = expressIdsVal["length"].as<uint32_t>();
+    uint32_t index = 0;
+    while (index < size)
+    {
+        emscripten::val expressIdVal = expressIdsVal[std::to_string(index++)];
+
+        uint32_t expressId = expressIdVal.as<uint32_t>();
+
+        expressIds.push_back(expressId);
+    }
+    
+    StreamMeshes(modelID, expressIds, callback);
 }
 
 void StreamAllMeshesWithTypes(uint32_t modelID, const std::vector<uint32_t>& types, emscripten::val callback)
@@ -1015,7 +1033,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     emscripten::function("IsModelOpen", &IsModelOpen);
     emscripten::function("GetGeometry", &GetGeometry);
     emscripten::function("GetFlatMesh", &GetFlatMesh);
-    emscripten::function("StreamMeshes", &StreamMeshes);
+    emscripten::function("StreamMeshes", &StreamMeshesVal);
     emscripten::function("GetCoordinationMatrix", &GetCoordinationMatrix);
     emscripten::function("StreamAllMeshes", &StreamAllMeshes);
     emscripten::function("StreamAllMeshesWithTypes", &StreamAllMeshesWithTypesVal);

--- a/src/web-ifc-api.ts
+++ b/src/web-ifc-api.ts
@@ -765,6 +765,16 @@ export class IfcAPI {
         this.wasmModule.CloseModel(modelID);
     }
 
+    /**
+	 * Streams meshes of a model with specific express id
+	 * @param modelID Model handle retrieved by OpenModel
+     * @param expressIDs expressIDs of elements to stream
+	 * @param meshCallback callback function that is called for each mesh
+	 */
+    StreamMeshes(modelID: number, expressIDs: Array<number>, meshCallback: (mesh: FlatMesh) => void) {
+        this.wasmModule.StreamMeshes(modelID, expressIDs,meshCallback);
+    }
+
 	/**
 	 * Streams all meshes of a model
 	 * @param modelID Model handle retrieved by OpenModel


### PR DESCRIPTION
StreamMeshes is not well registered to be used in Javascript or Node

This commit solves the following,

- In the file `web-ifc-api.ts` it defines StreamMeshes to be used in Javascript or Node. 
- In the file `web-ifc-api.cpp` it defines and registers `StreamMeshesVal` to Javascript/Node and allow pass second parameter as Javscript/Node array
