### PR TITLE
Add schema name when using OpenModel function

### DIFF
--- a/src/web-ifc-api.ts
+++ b/src/web-ifc-api.ts
@@ -277,6 +277,7 @@ export class IfcAPI {
         this.deletedLines.set(result,new Set());
         var schemaName = this.GetHeaderLine(result, FILE_SCHEMA).arguments[0][0].value;
         this.modelSchemaList[result] = this.LookupSchemaId(schemaName);
+        this.modelSchemaNameList[result] = schemaName;
         if (this.modelSchemaList[result] == -1) 
         {
             Log.error("Unsupported Schema:"+schemaName);


### PR DESCRIPTION
Due to a change  between version 0.0.41 and 0.0.42 the GetModelSchema function returns undefined when a model was obtained with OpenModel. 

This change re-adds the required line to OpenModel.