### PR TITLE
handle error if cant map expressid to globalid

### DIFF
--- a/src/web-ifc-api.ts
+++ b/src/web-ifc-api.ts
@@ -935,10 +935,14 @@ export class IfcAPI {
             for (let y = 0; y < size; y++) {
                 const expressID = lines.get(y);
                 const info = this.GetLine(modelID, expressID);
-                if ('GlobalId' in info) {
-                    const globalID = info.GlobalId.value;
-                    map.set(expressID, globalID);
-                    map.set(globalID, expressID);
+                try{
+                    if ("GlobalId" in info) {
+                        const globalID = info.GlobalId.value;
+                        map.set(expressID, globalID);
+                        map.set(globalID, expressID);
+                    }
+                } catch (e) {
+                    continue;
                 }
             }
         }


### PR DESCRIPTION
After updating from 0.40 to 0.42 this week, I checked if this issue got resolved with the last update. Sadly, seems like its producing a new error:

(issue) https://github.com/IFCjs/web-ifc/issues/381

(new error)
`
TypeError: Cannot use 'in' operator to search for 'GlobalId' in undefined
    at IfcAPI2.CreateIfcGuidToExpressIdMapping (VM529 web-ifc-api-node.js:63494:24)
`

And I think the pull request that got accepted yesterday (https://github.com/IFCjs/web-ifc/pull/439), I think would return the old error again when 0.43 gets released

So here is my pull request with a suggestion that should work I think