### PR TITLE
Make IfcBoolean and IfcLogical return the actual value. [Fixes #436]

### DIFF
--- a/src/schema-generator/gen_functional_types.ts
+++ b/src/schema-generator/gen_functional_types.ts
@@ -234,9 +234,6 @@ for (var i = 0; i < files.length; i++) {
           if (typeName=="number") {
             tsSchema.push(`public value: number;`);
             tsSchema.push(`constructor(v: any) { this.value = parseFloat(v);}`);
-          } else if (typeName=="boolean") {
-             tsSchema.push(`public value: boolean;`);
-              tsSchema.push(`constructor(v: any) { this.value = v == "true" ? true : false; }`);
           } else {
             tsSchema.push(`constructor(public value: ${typeName}) {}`);
           }


### PR DESCRIPTION
In previous implementations IfcBoolean and IfcLogical returned "T" for True, "F" for False or "U" for Unknown  – in the case of IfcLogical –. With the latest updates when calling GetLine IfcBoolean and IfcLogical get always false. This may be solved by checking for "T" instead of "true", but the proposal here is to leave the value as defined in the ifc file, with strict boolean values would be hard to identify IfcLogical's Unknown.