### PR TITLE
Prevent errors on GetLine when loading lines with mandatory attributes empty

### DIFF
--- a/src/schema-generator/gen_functional_types_helpers.ts
+++ b/src/schema-generator/gen_functional_types_helpers.ts
@@ -39,7 +39,7 @@ export function generatePropAssignment(p: Prop, i:number, types:Type[],schemaNam
     }
 
     let prefix = '';
-    if (p.optional) prefix ='!v['+i+'] ? null :'
+    if (p.optional || p.primitive) prefix ='!v['+i+'] ? null :'
 
     if (p.set)
     {


### PR DESCRIPTION
Some authoring tools generate lines with empty values – $ – where the schema enforces a required value.

E.g. GetLine throw an error when loads the following line:
```
#105530 = IFCWINDOWSTYLE('12oXYiBIL5ZeOtcy16wePW', #8, 'Geschossdecke:XXX_PLATZHALTER_HOL_16', $, $, (#105531), $, '38382177', $, $, $, $);
```

This happens because the generated function is expecting the last two values to be a IfcBoolean crashing on `v[10].value` 

In the case of a IfcWindowStyle line, this is the related function:
```
1299126871: (id, v) => new IFC2X3.IfcWindowStyle(id, new IFC2X3.IfcGloballyUniqueId(v[0].value), new Handle(v[1].value), !v[2] ? null : new IFC2X3.IfcLabel(v[2].value), !v[3] ? null : new IFC2X3.IfcText(v[3].value), !v[4] ? null : new IFC2X3.IfcLabel(v[4].value), !v[5] ? null : v[5].map((p) => new Handle(p.value)), !v[6] ? null : v[6].map((p) => new Handle(p.value)), !v[7] ? null : new IFC2X3.IfcLabel(v[7].value), v[8], v[9], v[10].value, v[11].value),
```