### PR TITLE
viewer: Fixed the renderization Front and Back face

### DIFF
--- a/examples/viewer/web-ifc-three.ts
+++ b/examples/viewer/web-ifc-three.ts
@@ -66,7 +66,7 @@ export class IfcThree
         if (geometries.length > 0)
         { 
             const combinedGeometry = BufferGeometryUtils.mergeBufferGeometries(geometries);
-            let mat = new THREE.MeshPhongMaterial();
+            let mat = new THREE.MeshPhongMaterial({side:THREE.DoubleSide});
             mat.vertexColors = true;
             const mergedMesh = new THREE.Mesh(combinedGeometry, mat);
             scene.add(mergedMesh);
@@ -75,7 +75,7 @@ export class IfcThree
         if (transparentGeometries.length > 0)
         {
             const combinedGeometryTransp = BufferGeometryUtils.mergeBufferGeometries(transparentGeometries);
-            let matTransp = new THREE.MeshPhongMaterial();
+            let matTransp = new THREE.MeshPhongMaterial({side:THREE.DoubleSide});
             matTransp.vertexColors = true;
             matTransp.transparent = true;
             matTransp.opacity = 0.5;

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "ts-jest": "^27.0.7",
         "ts-node": "^10.9.1",
         "typedoc": "^0.23.25",
-        "typescript": "^4.3.5"
+        "typescript": "^4.7.0"
       }
     },
     "node_modules/@75lb/deep-merge": {


### PR DESCRIPTION
web-ifc-three: Fixed the renderization Front and Back face of mesh f)rom merged geometries. Before only Front face was renderered so it caused no render some parts like this example,

![image](https://github.com/IFCjs/web-ifc/assets/7852409/631415f7-6065-4f58-9d87-10af504eff4c)


Now is fixed,

![image](https://github.com/IFCjs/web-ifc/assets/7852409/2ac08d5d-d21c-48e5-8a61-6dffa9211c8d)
